### PR TITLE
small fixes: changed to windows_sys, make page send, fix clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ categories = ["memory-management", "concurrency", "os", "no-std"]
 cfg-if = "1.0"
 lazy_static = "1.0"
 libc = "0.2"
-kernel32-sys = "0.2"
+windows-sys = { version = "0.45.0", features = ["Win32_System_Threading"] }


### PR DESCRIPTION
- Now using [windows_sys](https://github.com/microsoft/windows-rs) to fix #21 
- Make field `page` in Barrier send, previously implemented by #23
- fix clippy lint, previously implemented by #24, but not merged into master