### PR TITLE
Make `window-sys` dependency conditional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,6 @@ categories = ["memory-management", "concurrency", "os", "no-std"]
 cfg-if = "1.0"
 lazy_static = "1.4"
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.48.0", features = ["Win32_System_Threading"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ extern crate cfg_if;
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;
+#[cfg(windows)]
 extern crate windows_sys;
 
 #[allow(unused_macros)]


### PR DESCRIPTION
The crate currently fails to compile on Linux.